### PR TITLE
Fix errors in the JSON schema which may come from the UML

### DIFF
--- a/uml2json/schemas/iso19111.json
+++ b/uml2json/schemas/iso19111.json
@@ -40,7 +40,7 @@
     },
     "CartesianCS": {
       "$anchor": "CartesianCS",
-      "description": "two- or three-dimensional coordinate system in Euclidean space with straight axes that are not necessarily orthogonal\r\nNote: The number of associations shall equal the dimension of the coordinate system.",
+      "description": "two- or three-dimensional coordinate system in Euclidean space with orthogonal straight axes\r\nNote: All axes shall have the same length unit. A CartesianCS shall have two or three axis associations; the number of associations shall equal the dimension of the coordinate system.",
       "allOf": [
         {
           "$ref": "#/$defs/AffineCS"
@@ -183,7 +183,7 @@
     },
     "CoordinateOperation": {
       "$anchor": "CoordinateOperation",
-      "description": "mathematical operation (a) on coordinates that transforms or converts them from one coordinate reference system to another coordinate reference system, or (b) that decribes the change of coordinate values within one coordinate reference system due to the motion of the point between one coordinate epoch and another coordinate epoch\r\nNote: Many but not all coordinate operations (from CRS A to CRS B) also uniquely define the inverse coordinate operation (from CRS B to CRS A). In some cases, the coordinate operation method algorithm for the inverse coordinate operation is the same as for the forward algorithm, but the signs of some coordinate operation parameter values have to be reversed. In other cases, different algorithms are required for the forward and inverse coordinate operations, but the same coordinate operation parameter values are used. If (some) entirely different parameter values are needed, a different coordinate operation shall be defined.",
+      "description": "mathematical operation (a) on coordinates that transforms or converts them from one coordinate reference system to another coordinate reference system, or (b) that describes the change of coordinate values within one coordinate reference system due to the motion of the point between one coordinate epoch and another coordinate epoch\r\nNote: Many but not all coordinate operations (from CRS A to CRS B) also uniquely define the inverse coordinate operation (from CRS B to CRS A). In some cases, the coordinate operation method algorithm for the inverse coordinate operation is the same as for the forward algorithm, but the signs of some coordinate operation parameter values have to be reversed. In other cases, different algorithms are required for the forward and inverse coordinate operations, but the same coordinate operation parameter values are used. If (some) entirely different parameter values are needed, a different coordinate operation shall be defined.",
       "allOf": [
         {
           "$ref": "#/$defs/ObjectUsage"
@@ -239,7 +239,7 @@
               ]
             },
             "interpolationCRS": {
-              "description": "\"coordinate reference system to which gridded data files are referenced which this coordinate operation uses to  transform coordinates between two other coordinate reference systems\r\nNote: InterpolationCRS is only used when it is different from both sourceCRS and targetCRS.\"",
+              "description": "coordinate reference system to which gridded data files are referenced which this coordinate operation uses to  transform coordinates between two other coordinate reference systems\r\nNote: InterpolationCRS is only used when it is different from both sourceCRS and targetCRS.",
               "oneOf": [
                 {
                   "type": "string",
@@ -496,7 +496,7 @@
     },
     "DefiningParameter": {
       "$anchor": "DefiningParameter",
-      "description": "parameter value, an ordered sequence of values, or a reference to a file of parameter values that define a paramtric datum",
+      "description": "parameter value, an ordered sequence of values, or a reference to a file of parameter values that define a parametric datum",
       "allOf": [
         {
           "$ref": "#/$defs/IdentifiedObject"
@@ -1056,6 +1056,7 @@
               "uniqueItems": true
             },
             "definingTransformation": {
+              "description": "transformation that defines this geodetic coordinate reference system",
               "type": "array",
               "items": {
                 "oneOf": [
@@ -1488,7 +1489,7 @@
           }
         },
         "valueFile": {
-          "description": "reference to a file or an identified part of a file containing one or more parameter values\" and note changed to \"Note: The referenced file or part of a file can reference another part of the same or different files, as allowed in XML documents",
+          "description": "reference to a file or a part of a file containing one or more parameter values\r\nNote: When referencing a part of a file, that file shall contain multiple identified parts, such as an XML encoded document. Furthermore, the referenced file or part of a file can reference another part of the same or different files, as allowed in XML documents.",
           "type": "string"
         },
         "valueFileCitation": {
@@ -1679,7 +1680,7 @@
     },
     "PointMotionOperation": {
       "$anchor": "PointMotionOperation",
-      "description": "mathematical operation that decribes the change of coordinate values within one coordinate reference system due to the motion of the point between one coordinate epoch and another coordinate epoch \r\nNote: In this document the motion is due to tectonic plate movement or deformation.",
+      "description": "mathematical operation that describes the change of coordinate values within one coordinate reference system due to the motion of the point between one coordinate epoch and another coordinate epoch \r\nNote: In this document the motion is due to tectonic plate movement or deformation.",
       "allOf": [
         {
           "$ref": "#/$defs/SingleOperation"


### PR DESCRIPTION
Fix errors in the JSON schema which may come from the UML:

* Description of the `CartesianCS` class was a copy of `AffineCS` description.
* Missing description `GeodeticCRS.definingTransformation`.
* Spurious text in `ParameterValue.valueFile`.
* Spurious escaped quotes in `CoordinateOperation.interpolationCRS`.
* Typo: "paramtric" → "parametric" (one occurence).
* Typo: "decribe" → "describe" (two occurences).
